### PR TITLE
use https instead of http for the iframe sample App.

### DIFF
--- a/iframe_sample_app/app.js
+++ b/iframe_sample_app/app.js
@@ -1,6 +1,6 @@
 (function() {
 
-  var SIDE_BAR_HREF = "https://www.facebook.com",
+  var SIDE_BAR_HREF = "https://www.wikipedia.org",
       SIDE_BAR_REGEX = /_sidebar$/;
 
   return {


### PR DESCRIPTION
:koala: :+1: 

Lotus is through https. Current iframe sample App has http://wikipedia.com as source. If one uploads a zip to an account on the production server, wikipedia page won't show up in iframe by default. User has to enable unsafe script.

Hence, I am changing the iframe source to https://www.wikipedia.org.
### Note:

I believe that not many https sites allows for iframe embedding for security reason. Wikipedia is generous :D

/cc @jwswj @maximeprades @zendesk/quokka @princemaple @liulikun 
