### PR TITLE
[APPS-1729] Remove regex in favour of subdomain API

### DIFF
--- a/top_bar_sample_app/app.js
+++ b/top_bar_sample_app/app.js
@@ -3,7 +3,6 @@
   'use strict';
 
   var EVENT_NAME        = 'send_message',
-      SUBDOMAIN_PATTERN = /[a-zA-Z0-9]+\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+/,// Pattern for subdomain.zendesk.com extraction.
       SIZES             = {
         small: {
           width: 280,
@@ -33,21 +32,19 @@
       this.isNotified = false;
     },
 
-    startPage: function(e) {
-      // Run regular expression to extract subdomain
-      var regexResult = SUBDOMAIN_PATTERN.exec(e.currentTarget.baseURI);
+    startPage: function() {
       // These parameters are handlebars parameters in the instruction page that renders a cURL command
       this.switchTo('instruction', {
         app_id: this.id(),
         event: EVENT_NAME,
-        url: regexResult[0], // This gets the matched URL.
+        subdomain: this.currentAccount().subdomain(),
         email: this.currentUser().email()
       });
     },
 
-    paneOnActivated: function(e) {
+    paneOnActivated: function() {
       if (!this.isNotified) {
-        this.startPage(e);
+        this.startPage();
       }
 
       // Resize after pane is activated.

--- a/top_bar_sample_app/templates/instruction.hdbs
+++ b/top_bar_sample_app/templates/instruction.hdbs
@@ -9,6 +9,6 @@
     </ol>
   </span>
   <span>
-    <code>curl -v -u {{email}}/token:{your API access_token} https://{{url}}/api/v2/apps/notify.json -H "Content-Type: application/json" -X POST -d '{"event": "{{event}}", "app_id": "{{app_id}}", "body":"Hello World!"}'</code>
+    <code>curl -v -u {{email}}/token:{your API access_token} https://{{subdomain}}.zendesk.com/api/v2/apps/notify.json -H "Content-Type: application/json" -X POST -d '{"event": "{{event}}", "app_id": "{{app_id}}", "body":"Hello World!"}'</code>
   </span>
 </div>


### PR DESCRIPTION
:koala: :+1: 

Remove regex in favour of subdomain API, demonstrating best practices in our demo apps.

This uses a hard-coded `.zendesk.com` subdomain which will be incorrect in staging and acceptance environments, but should be good enough for a public demo app as it was completely broken in those environments anyway.

/cc @zendesk/quokka
### References
- Jira link: https://zendesk.atlassian.net/browse/APPS-1729
### Risks
- None
