### PR TITLE
add mandatory field to requirements.json

### DIFF
--- a/requirements_only_sample_app/requirements.json
+++ b/requirements_only_sample_app/requirements.json
@@ -19,7 +19,8 @@
       "title": "Test JSON to requestbin",
       "method": "post",
       "content_type": "application/json",
-      "target_url": "http://requestb.in/13ualp61"
+      "target_url": "http://requestb.in/13ualp61",
+      "attribute": "message_value"
     }
   },
 


### PR DESCRIPTION
:koala:

Makes this app installable.
Search for url_target under https://developer.zendesk.com/rest_api/docs/core/targets to see `attribute` is marked as mandatory.

/cc @zendesk/quokka