### PR TITLE
Bye bye app.activated

### DIFF
--- a/v1/apps_notification_sample_app/app.js
+++ b/v1/apps_notification_sample_app/app.js
@@ -2,7 +2,7 @@
 
   return {
     events: {
-      'app.activated':       'initApp',
+      'app.created':         'initApp',
       'click .btn-growl-it': 'growlIt'
     },
 

--- a/v1/basic_organization_sample_app/app.js
+++ b/v1/basic_organization_sample_app/app.js
@@ -6,7 +6,7 @@
     requests: {},
 
     events: {
-      'app.activated': function(){
+      'app.created': function(){
         var organization = this.organization();
 
         this.switchTo('basic_organization_info', {

--- a/v1/basic_ticket_sample_app/app.js
+++ b/v1/basic_ticket_sample_app/app.js
@@ -3,7 +3,7 @@
   return { // the entire app goes inside this return block!
     // listen for API events such as the start of our app, when bits of it get clicked on or when AJAX requests complete
     events: {
-      'app.activated':                'initialize', // this event runs when the app activates - for sidebar apps, whenever the user navigates to a location the app exists
+      'app.created':                  'initialize', // this event runs when the app is created
       'ticket.collaborators.changed': 'newCCs', // API event fired when the ticket type changes (eg a ticket is marked as an Incident or a Question is changed to a Problem)
       'click .nav-pills .account':    'tabClicked', // DOM event fired when the user clicks an option on the account tab
       'click .nav-pills .user':       'tabClicked',
@@ -16,10 +16,8 @@
     requests: {
     },
 
-    initialize: function(data) { // function called when we load
-      if (data.firstLoad) {
-        this.switchTo('main');
-      }
+    initialize: function() { // function called when we load
+      this.switchTo('main');
     },
 
     // UI Events

--- a/v1/basic_user_sample_app/app.js
+++ b/v1/basic_user_sample_app/app.js
@@ -6,7 +6,7 @@
     requests: {},
 
     events: {
-      'app.activated': function(){
+      'app.created': function(){
         var user = this.currentUser();
         var groups = user.groups();
 

--- a/v1/common_js_sample_app/lib/events.js
+++ b/v1/common_js_sample_app/lib/events.js
@@ -1,4 +1,4 @@
 module.exports = {
-  'app.activated': 'requestBookmarks',
+  'app.created': 'requestBookmarks',
   'fetchBookmarks.done': 'fetchBookmarksDone'
 };

--- a/v1/expert_sample_app/app.js
+++ b/v1/expert_sample_app/app.js
@@ -36,7 +36,7 @@
     },
 
     events: {
-      'app.activated'      : 'init',
+      'app.created'        : 'init',
       'ticket.save'        : 'saveHookHandler',
       'ticket.submit.done' : 'ticketSubmitDoneHandler',
       'hidden .my_modal'   : 'modalIsHiddenHandler',

--- a/v1/external_api_sample_app/app.js
+++ b/v1/external_api_sample_app/app.js
@@ -65,7 +65,7 @@
     },
 
     events: {
-      'app.activated'                : 'init',
+      'app.created'                  : 'init',
       'click .get_no_auth'           : 'getNoAuth',
       'click .get_with_auth'         : 'getWithAuth',
       'click .post_with_auth'        : 'openEditUserForm',

--- a/v1/hello_world_sample_app/README.md
+++ b/v1/hello_world_sample_app/README.md
@@ -5,7 +5,7 @@ This very simple sample app shows you the very basics of our Apps framework and 
 ### The following information is displayed:
 
 * 1 template with the name of the current logged in Agent.
-* The app.activated event.
+* The app.created event.
 
 Please submit bug reports to [Zendesk Support](https://support.zendesk.com/hc). Pull requests are welcome.
 

--- a/v1/hello_world_sample_app/app.js
+++ b/v1/hello_world_sample_app/app.js
@@ -2,7 +2,7 @@
 
   return {
     events: {
-      'app.activated': 'sayHello'
+      'app.created': 'sayHello'
     },
 
     sayHello: function() {

--- a/v1/interface_api_sample_app/app.js
+++ b/v1/interface_api_sample_app/app.js
@@ -3,7 +3,7 @@
   return {
 
     events: {
-      'app.activated':'initialize', // this event is run once when the app loads and calls the 'initialize' function
+      'app.created': 'initialize', // this event is run once when the app loads and calls the 'initialize' function
       '*.changed': 'detectedChange', // this event runs when there is a change in the ticket fields
       'click .nav-pills .showhide': 'initialize',
       'click .nav-pills .rename': 'drawRename',

--- a/v1/jwt_sample_app/app.js
+++ b/v1/jwt_sample_app/app.js
@@ -22,7 +22,7 @@
     },
 
     events: {
-      'app.activated':'init'
+      'app.created': 'init'
     },
 
     init: function() {

--- a/v1/modal_js_sample_app/app.js
+++ b/v1/modal_js_sample_app/app.js
@@ -6,7 +6,7 @@
   return {
 
     events: {
-      'app.activated': 'init',
+      'app.created': 'init',
       'show .my_modal': 'onShow',
       'click .toggle_modal': 'displayModal',
       'click .save_button': 'showSavedMessage'

--- a/v1/modal_sample_app/app.js
+++ b/v1/modal_sample_app/app.js
@@ -3,7 +3,7 @@
   return {
 
     events: {
-      'app.activated': 'init',
+      'app.created': 'init',
       'hidden .my_modal': 'afterHidden' // The 'hidden' event is fired when the modal (.my_modal) has finished being hidden from the user (will wait for css transitions to complete).
     },
 

--- a/v1/requirements_sample_app/app.js
+++ b/v1/requirements_sample_app/app.js
@@ -2,7 +2,7 @@
 
   return {
     events: {
-      'app.activated': 'doSomething'
+      'app.created': 'doSomething'
     },
 
     doSomething: function() {

--- a/v1/reuseable_template_app/README.md
+++ b/v1/reuseable_template_app/README.md
@@ -5,7 +5,7 @@ This very simple sample app shows you how to reuse templates in Zendesk apps. It
 ### The following information is displayed:
 
 * A template that says hello, and another template that says goodbye. Both templates include a common template.
-* The app.activated event.
+* The app.created event.
 * Click events.
 
 Please submit bug reports to [Zendesk Support](https://support.zendesk.com/hc). Pull requests are welcome.

--- a/v1/reuseable_template_app/app.js
+++ b/v1/reuseable_template_app/app.js
@@ -2,7 +2,7 @@
 
   return {
     events: {
-      'app.activated': 'greet',
+      'app.created': 'greet',
       'click a': 'handleButton'
     },
 

--- a/v1/save_hook_sample_app/app.js
+++ b/v1/save_hook_sample_app/app.js
@@ -17,8 +17,8 @@
 
     events: {
 
-      'app.activated': 'init',
-      'ticket.save':   'hookHandler',
+      'app.created': 'init',
+      'ticket.save': 'hookHandler',
 
       // Switch to different hook handlers
       'click .simple_pass':  'useSimplePass',  // pass

--- a/v1/secure_requests_sample_app/app.js
+++ b/v1/secure_requests_sample_app/app.js
@@ -23,7 +23,7 @@
     },
 
     events: {
-      'app.activated'           : 'init',
+      'app.created'             : 'init',
       'click .fetch'            : 'getInfo',
       'getFromTeachmyapi.done'  : 'renderInfo',
       'getFromTeachmyapi.fail'  : 'fail',

--- a/v1/top_bar_sample_app/app.js
+++ b/v1/top_bar_sample_app/app.js
@@ -20,7 +20,7 @@
   return {
 
     events: {
-      'app.activated': 'init', // This event fires when App is activated.
+      'app.created': 'init', // This event fires when App is created.
       'pane.activated': 'paneOnActivated', // This event fires when pane in topbar is activated.
       'pane.deactivated': 'paneOnDeactivated',
       'notification.send_message': 'showNoticeBoard', // Capture notification event 'send_message'

--- a/v1/zendesk_rest_api_sample_app/app.js
+++ b/v1/zendesk_rest_api_sample_app/app.js
@@ -85,7 +85,7 @@
     },
 
     events: {
-      'app.activated': 'initialize',
+      'app.created': 'initialize',
       'app.willDestroy': 'cleanUp',
 
       // Installations


### PR DESCRIPTION
:v:

We see too many app developers performing initial setup on `app.activated`. This is expensive for ticket sidebar apps since it gets called whenever the user switches to a ticket tab. This PR replaces misleading examples of `app.activated` for `app.created`.

/cc @zendesk/vegemite