### PR TITLE
Correct dev twitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ This repository provides you with sample Apps to help learn how to use the Zende
   * [Chat APIs](./v2/chat)
 * [ZAF v1 demo apps](./v1)
 
-We hope you'll find those sample Apps useful and encourage you to re-use some of this code in your own Apps. If you have any questions please email support@zendesk.com or find us on [Twitter](https://twitter.com/zendeskdevteam). Please submit bug reports to [Zendesk](https://support.zendesk.com/requests/new). Pull requests are welcome.
+We hope you'll find those sample Apps useful and encourage you to re-use some of this code in your own Apps. If you have any questions please email support@zendesk.com or find us on [Twitter](https://twitter.com/zendeskdevs). Please submit bug reports to [Zendesk](https://support.zendesk.com/requests/new). Pull requests are welcome.


### PR DESCRIPTION
The correct twitter page for Zendesk Dev is wrong!  Fix it!

@zendesk/vegemite @zendesk/sustaining 