### PR TITLE
Removing package keys from demo app translations

### DIFF
--- a/v1/apps_notification_sample_app/translations/en.json
+++ b/v1/apps_notification_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "app_name",
     "description": {
       "value": "Show how notifications work in an app",
       "title": "app description"

--- a/v1/basic_organization_sample_app/translations/en.json
+++ b/v1/basic_organization_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "basic_organization_sample",
     "description": {
       "value": "this app shows organization info",
       "title": "app description"

--- a/v1/basic_ticket_sample_app/translations/en.json
+++ b/v1/basic_ticket_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "basic_ticket_sample",
     "description": {
       "value": "Demo of ticket, user and account APIs",
       "title": "app description"

--- a/v1/basic_user_sample_app/translations/en.json
+++ b/v1/basic_user_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "basic_user_sample",
     "description": {
       "value": "this app shows user info",
       "title": "app description"

--- a/v1/common_js_sample_app/translations/en.json
+++ b/v1/common_js_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "common_js_sample_app",
     "description": {
       "value": "An app that shows how you can use CommonJS modules in your code",
       "title": "app description"

--- a/v1/conditional_locations_sample_app/translations/en.json
+++ b/v1/conditional_locations_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "conditonal_locations_sample_app",
     "description": {
       "value": "This app demonstrates how to use conditonal locations APIs",
       "title": "app description"

--- a/v1/expert_sample_app/translations/en.json
+++ b/v1/expert_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "expert_sample_app",
     "description": {
       "value": "This App shows the use of promises, save hook, handlebars helper, underscore, bootstrap 2.3 elements, App interface and settings, Zendesk RESTful API and etc.",
       "title": "app description"

--- a/v1/external_api_sample_app/translations/en.json
+++ b/v1/external_api_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "external_rest_api_sample_app",
     "description": {
       "value": "Shows how to make REST request to non-Zendesk endpoints in App.",
       "title": "app description"

--- a/v1/hello_world_sample_app/translations/en.json
+++ b/v1/hello_world_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "hello_world_sample",
     "name": {
       "value": "Hello World App",
       "title": "app name"

--- a/v1/iframe_sample_app/translations/en.json
+++ b/v1/iframe_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "iframe_sample_app",
     "description": {
       "value": "Display the Zendesk Apps Introduction page and Zendesk Support page in iframe",
       "title": "iFrame Sample App"

--- a/v1/interface_api_sample_app/translations/en.json
+++ b/v1/interface_api_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "interface_api_sample",
     "description": {
       "value": "Demo interacting with the ticket fields and ticket interface",
       "title": "app description"

--- a/v1/jwt_sample_app/translations/en.json
+++ b/v1/jwt_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "app_name",
     "description": {
       "value": "Play the famous zen tunes in your help desk.",
       "title": "app description"

--- a/v1/localStorage_sample_app/translations/en.json
+++ b/v1/localStorage_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "app_name",
     "description": {
       "value": "Play the famous zen tunes in your help desk.",
       "title": "app description"

--- a/v1/localStorage_value_checker_sample_app/translations/en.json
+++ b/v1/localStorage_value_checker_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "app_name",
     "description": {
       "value": "Play the famous zen tunes in your help desk.",
       "title": "app description"

--- a/v1/modal_js_sample_app/translations/en.json
+++ b/v1/modal_js_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "modal_sample_app",
     "description":  {
       "value": "Discover all about modal specific events, and invoking a modal",
       "title": "app description"

--- a/v1/modal_sample_app/translations/en.json
+++ b/v1/modal_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "modal_sample_app",
     "description":  {
       "value": "Discover all about modal specific events, and invoking a modal",
       "title": "app description"

--- a/v1/requirements_only_sample_app/translations/en.json
+++ b/v1/requirements_only_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "requirements_only",
     "name": {
       "value": "Requirements Only App",
       "title": "app name"

--- a/v1/requirements_sample_app/translations/en.json
+++ b/v1/requirements_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "requirements_only",
     "name": {
       "value": "Requirements Only App",
       "title": "app name"

--- a/v1/reuseable_template_app/translations/en.json
+++ b/v1/reuseable_template_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "reusable_template_sample",
     "name": {
       "value": "Reusable Template App",
       "title": "app name"

--- a/v1/save_hook_sample_app/translations/en.json
+++ b/v1/save_hook_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "save_hook_sample",
     "description": {
       "value": "show how to use ticket.save hook",
       "title": "app description"

--- a/v1/secure_requests_sample_app/translations/en.json
+++ b/v1/secure_requests_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "secure_demo_app",
     "description": {
       "value": "Show how secure works.",
       "title": "app description"

--- a/v1/settings_sample_app/translations/en.json
+++ b/v1/settings_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "settings_sample_app",
     "description": {
       "value": "This app demonstrates how to use and edit app settings in manifest.json",
       "title": "app description"

--- a/v1/top_bar_sample_app/translations/en.json
+++ b/v1/top_bar_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "top_bar_sample_app",
     "description": {
       "value": "send a curl command from your terminal to make your topbar app popover!",
       "title": "app description"

--- a/v1/zendesk_rest_api_sample_app/translations/en.json
+++ b/v1/zendesk_rest_api_sample_app/translations/en.json
@@ -1,6 +1,5 @@
 {
   "app": {
-    "package": "zendesk_rest_api_sample",
     "description": {
       "value": "Show off Zendesk REST API and this.currentLocation() API",
       "title": "app description"

--- a/v2/support/requirements_only_sample_app/translations/en.json
+++ b/v2/support/requirements_only_sample_app/translations/en.json
@@ -3,7 +3,6 @@
     "installation_instructions": "Find the app in the Zendesk marketplace.",
     "long_description": "Requirements only app.",
     "short_description": "Requirements only app.",
-    "package": "requirements_only",
     "name": {
       "value": "Requirements Only App",
       "title": "app name"

--- a/v2/support/requirements_sample_app/translations/en.json
+++ b/v2/support/requirements_sample_app/translations/en.json
@@ -3,7 +3,6 @@
     "installation_instructions": "Find the app in the Zendesk marketplace.",
     "long_description": "Requirements sample app.",
     "short_description": "Requirements sample app.",
-    "package": "requirements_sample",
     "name": {
       "value": "Requirements Sample App",
       "title": "app name"


### PR DESCRIPTION
Per Daniel in https://support.zendesk.com/hc/en-us/community/posts/209137097-About-the-package-property-that-alters-how-translations-are-validated-using-zat the package key in translations is only used internally. I confirmed with him via Slack that these should be removed. As always, feedback is welcome.