### PR TITLE
requirements sample apps don't pass zat validate

### DIFF
--- a/v2/support/requirements_only_sample_app/translations/en.json
+++ b/v2/support/requirements_only_sample_app/translations/en.json
@@ -3,9 +3,6 @@
     "installation_instructions": "Find the app in the Zendesk marketplace.",
     "long_description": "Requirements only app.",
     "short_description": "Requirements only app.",
-    "name": {
-      "value": "Requirements Only App",
-      "title": "app name"
-    }
+    "name": "Requirements Only App"
   }
 }

--- a/v2/support/requirements_only_sample_app/translations/en.json
+++ b/v2/support/requirements_only_sample_app/translations/en.json
@@ -3,7 +3,6 @@
     "installation_instructions": "Find the app in the Zendesk marketplace.",
     "long_description": "Requirements only app.",
     "short_description": "Requirements only app.",
-    "package": "requirements_only",
     "name": {
       "value": "Requirements Only App",
       "title": "app name"

--- a/v2/support/requirements_sample_app/translations/en.json
+++ b/v2/support/requirements_sample_app/translations/en.json
@@ -3,9 +3,6 @@
     "installation_instructions": "Find the app in the Zendesk marketplace.",
     "long_description": "Requirements sample app.",
     "short_description": "Requirements sample app.",
-    "name": {
-      "value": "Requirements Sample App",
-      "title": "app name"
-    }
+    "name": "Requirements Sample App"
   }
 }

--- a/v2/support/requirements_sample_app/translations/en.json
+++ b/v2/support/requirements_sample_app/translations/en.json
@@ -3,7 +3,6 @@
     "installation_instructions": "Find the app in the Zendesk marketplace.",
     "long_description": "Requirements sample app.",
     "short_description": "Requirements sample app.",
-    "package": "requirements_sample",
     "name": {
       "value": "Requirements Sample App",
       "title": "app name"


### PR DESCRIPTION
removing "package" key from en.json translations in the following apps to pass zat validate:
requirements_sample_app
requirements_only_sample_app