### PR TITLE
Allow option to adopt a new cat

### DIFF
--- a/v2/support/secure_settings_sample_app/assets/iframe.html
+++ b/v2/support/secure_settings_sample_app/assets/iframe.html
@@ -12,7 +12,7 @@
   <script type="text/javascript" src="https://assets.zendesk.com/apps/sdk/2.0/zaf_sdk.js"></script>
   <script>
     // Initialise the Zendesk JavaScript API client
-    // https://developer.zendesk.com/apps/docs/apps-v2
+    // https://developer.zendesk.com/apps/docs/developer-guide/getting_started
     var client = ZAFClient.init();
 
     var settings = {

--- a/v2/support/secure_settings_sample_app/assets/iframe.html
+++ b/v2/support/secure_settings_sample_app/assets/iframe.html
@@ -3,9 +3,11 @@
   <meta charset="utf-8">
   <!-- http://garden.zendesk.com -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@zendeskgarden/css-bedrock@7.0" type="text/css">
+  <link rel="stylesheet" href="styles.css" type="text/css">
 </head>
 <body>
-  <img class="cat-picture" height="200" width="250"></h2>
+  <img class="cat-picture" height="200" width="250"></img>
+  <div class="button" id="new-cat-button" height="20" width="50">Adopt a new cat</div>
   <!-- https://github.com/zendesk/zendesk_app_framework_sdk -->
   <script type="text/javascript" src="https://assets.zendesk.com/apps/sdk/2.0/zaf_sdk.js"></script>
   <script>
@@ -13,25 +15,35 @@
     // https://developer.zendesk.com/apps/docs/apps-v2
     var client = ZAFClient.init();
 
+    var settings = {
+      url: 'https://api.thecatapi.com/v1/images/search?format=json',
+      headers: {"x-api-key": "{{setting.api_token}}"},
+      secure: true,
+      type: 'GET',
+      contentType: 'application/json'
+    };
+
     function renderImage(catPictureLink) {
       var catPictureElement = document.querySelector("img[class='cat-picture']");
       catPictureElement.src = catPictureLink;
     }
 
-    client.on('app.registered', function() {
-      var settings = {
-        url: 'https://api.thecatapi.com/v1/images/search?format=json',
-        headers: {"x-api-key": "{{setting.api_token}}"},
-        secure: true,
-        type: 'GET',
-        contentType: 'application/json'
-      };
+    function fetchNewCat() {
       client.request(settings).then(function(data) {
         var cat_image_link = data['0']['url'];
         renderImage(cat_image_link);
       });
+    }
+
+    client.on('app.registered', function() {
+      fetchNewCat();
       client.invoke('resize', { width: '100%', height: '200px' });
     });
+
+    var button = document.getElementById('new-cat-button')
+
+    button.addEventListener('click', fetchNewCat, false);
+
   </script>
 </body>
 </html>

--- a/v2/support/secure_settings_sample_app/assets/styles.css
+++ b/v2/support/secure_settings_sample_app/assets/styles.css
@@ -1,0 +1,6 @@
+div.button {
+  color: yellow;
+  background-color: blue;
+  border-style: solid;
+  border-width: 2px;
+}


### PR DESCRIPTION
After listening to our customers, we learned that often people wanted to adopt new cats without leaving the animal shelter!  Therefore in this iteration:

* A new amazing and shiny button added to the Secure Settings Sample App
* The ability to fetch different cats when you click the button

Demo:

![AdoptANewCat](https://user-images.githubusercontent.com/1825818/54731971-66744280-4be5-11e9-8cfe-172586e5729a.gif)

cc @zendesk/vegemite 