### PR TITLE
do not display default attributes added to profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.zip
 **/.zat
 **/tmp
+*.swp
 
 .DS_Store

--- a/v2/sunshine/user_profiles_app/assets/index.html
+++ b/v2/sunshine/user_profiles_app/assets/index.html
@@ -81,8 +81,21 @@
         content: `${key ? profileKeyElement({ key, indentationStyle }) : ''}${value ? profileValueElement({ value, indentationStyle }): ''}`
       })
 
+    const DEFAULT_ATTRIBUTES_TO_IGNORE = new Set([
+      'current_location',
+      'do_not_track_location',
+      'role_id',
+    ])
+
+    const filterRootKeys = depth => {
+      if (depth === 0) {
+        return key => !DEFAULT_ATTRIBUTES_TO_IGNORE.has(key)
+      }
+      return key => key
+    }
+
     const renderNestedObject = (object, toId, depth = 0) => {
-      const keys = Object.keys(object)
+      const keys = Object.keys(object).filter(filterRootKeys(depth))
       const indentationStyle = `margin-left:${depth * INDENT_PX}px`
       if (keys.length < 1) {
         appendElementById({


### PR DESCRIPTION
certain attributes are added to profile objects by default such as `current_location`. this PR fulfills the request of a couple solution engineers to hide these attributes by default when displaying user profiles.

<img width="347" alt="Screen Shot 2019-06-11 at 9 43 49 AM" src="https://user-images.githubusercontent.com/4695062/59290608-d0711680-8c2d-11e9-9c7c-96fc41a6a642.png">
